### PR TITLE
fix: Only initialize when we have size

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,7 +37,7 @@ class _BenchMarkScreenState extends State<BenchMarkScreen>
   bool _isInitialized = false;
 
   Future<void> _initWithContext(BuildContext context) async {
-    _bounds = MediaQuery.of(context).size;
+    _bounds = MediaQuery.sizeOf(context);
     final bunnyImage = await loadImage("bunny_atlas.png");
     _initBunnies(bunnyImage);
     _ticker = createTicker((_) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,7 @@ class _BenchMarkScreenState extends State<BenchMarkScreen>
   }
 
   void _initBunnies(ui.Image bunnyImage) {
-    const int bunnyCount = 1500;
+    const int bunnyCount = 300;
     bunnies.clear();
     final random = Random(33);
     for (int i = 0; i < bunnyCount; i++) {
@@ -95,16 +95,22 @@ class _BenchMarkScreenState extends State<BenchMarkScreen>
 
   @override
   Widget build(BuildContext context) {
-    if (!_isInitialized) {
-      SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
-        _isInitialized = true;
-        _initWithContext(context);
-      });
-      return Container();
-    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (!_isInitialized) {
+          if (!constraints.biggest.isEmpty) {
+            SchedulerBinding.instance.addPostFrameCallback((timeStamp) {
+              _isInitialized = true;
+              _initWithContext(context);
+            });
+          }
+          return Container();
+        }
 
-    return SizedBox.expand(
-      child: CustomPaint(painter: BunnyPainter(bunnies: bunnies)),
+        return SizedBox.expand(
+          child: CustomPaint(painter: BunnyPainter(bunnies: bunnies)),
+        );
+      },
     );
   }
 


### PR DESCRIPTION
Since there is a race for getting the media query size it will sometimes be zero, this PR fixes so that we wait with initialization until we have a size.